### PR TITLE
14 leaderboard mutation

### DIFF
--- a/app/graphql/mutations/create_leaderboard.rb
+++ b/app/graphql/mutations/create_leaderboard.rb
@@ -1,0 +1,24 @@
+class Mutations::CreateLeaderboard < Mutations::BaseMutation
+  argument :name, String, required: true
+  argument :score, Integer, required: true
+  argument :category, String, required: true
+  argument :difficulty, String, required: true
+  
+  field :leaderboard, Types::LeaderboardType, null: false
+  field :errors, [String], null: false
+
+  def resolve(name:, score:, category:, difficulty:)
+    leaderboard = Leaderboard.new(name: name, score: score, category: category, difficulty: difficulty)
+    if leaderboard.save
+      {
+        leaderboard: leaderboard,
+        errors: []
+      }
+    else
+      {
+        leaderboard: nil,
+        errors: leaderboard.errors.full_messages
+      }
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,10 +1,5 @@
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    # field :test_field, String, null: false,
-    #   description: "An example field added by the generator"
-    # def test_field
-    #   "Hello World"
-    # end
+    field :create_leaderboard, mutation: Mutations::CreateLeaderboard
   end
 end

--- a/spec/requests/leaderboard_mutation_spec.rb
+++ b/spec/requests/leaderboard_mutation_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'leaderboard mutation', type: :request do
+  it 'adds a leaderboard entry to the database' do
+    mutation_response = leaderboards_mutation
+    leaderboard = mutation_response["createLeaderboard"]["leaderboard"]
+    errors = mutation_response["createLeaderboard"]["errors"]
+    new_leaderboard = Leaderboard.last
+
+    expect(leaderboard["name"]).to eq(new_leaderboard.name)
+    expect(leaderboard["score"]).to eq(new_leaderboard.score)
+    expect(leaderboard["difficulty"]).to eq(new_leaderboard.difficulty)
+    expect(leaderboard["category"]).to eq(new_leaderboard.category)
+    expect(errors).to eq([])
+  end
+
+  private
+
+  def leaderboards_mutation()
+    response = gql <<-GQL
+      mutation createLeaderBoard{
+        createLeaderboard(input: {
+          name: "Bojack",
+          score: 100,
+          category: "Animals",
+          difficulty: "Hard"
+        }) {
+          leaderboard {
+            name
+            score
+            difficulty
+            category
+          }
+          errors
+        }
+      }
+    GQL
+
+    response.dig('data')
+  end
+end


### PR DESCRIPTION
## Query/Mutation Effected #14 
Creates the mutation createLeaderboard

## Describe Changes
Add mutation and mutation type for creating a leaderboard

Example request
```
mutation createLeaderBoard{
  createLeaderboard(input: {
    name: "Dave Grohl"
    score: 100
    category: "Animals"
    difficulty: "Hard"
  }) {
    leaderboard {
      name
      score
      difficulty
      category
    }
    errors
  }
}
```
## Requested Reviewer(s)
@ryancanton 