### PR TITLE
Add difficulty to deck

### DIFF
--- a/app/graphql/mutations/create_deck.rb
+++ b/app/graphql/mutations/create_deck.rb
@@ -3,11 +3,12 @@
 module Mutations
   class CreateDeck < Mutations::BaseMutation
     argument :category, String, required: true
+    argument :difficulty, String, required: true
 
     field :deck, Types::DeckType
     field :errors, [String], null: false
 
-    def resolve(category:)
+    def resolve(category:, difficulty:)
       deck = Deck.new(category: category)
       if deck.save
         if deck.sound_cards.count.positive?

--- a/app/graphql/mutations/create_deck.rb
+++ b/app/graphql/mutations/create_deck.rb
@@ -9,7 +9,7 @@ module Mutations
     field :errors, [String], null: false
 
     def resolve(category:, difficulty:)
-      deck = Deck.new(category: category)
+      deck = Deck.new(category: category, difficulty: difficulty)
       if deck.save
         if deck.sound_cards.count.positive?
           {
@@ -20,7 +20,7 @@ module Mutations
           deck.destroy
           {
             deck: nil,
-            errors: ["There are no sound cards for category #{category}"]
+            errors: ["There are no sound cards for category #{category} with difficulty #{difficulty}"]
           }
         end
       else

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Deck < ApplicationRecord
-  validates_presence_of :category
+  validates_presence_of :category, :difficulty
   has_many :deck_cards, dependent: :destroy
   has_many :sound_cards, through: :deck_cards
   after_create :add_sound_cards
@@ -25,6 +25,6 @@ class Deck < ApplicationRecord
   end
 
   def initial_sound_cards
-    SoundCard.where('lower(category) ILIKE ?', "%#{category.downcase}%").shuffle.sample(8)
+    SoundCard.where('lower(category) ILIKE ?', "%#{category.downcase}%").where('lower(difficulty) ILIKE ?', "%#{difficulty.downcase}").shuffle.sample(8)
   end
 end

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -25,6 +25,7 @@ class Deck < ApplicationRecord
   end
 
   def initial_sound_cards
-    SoundCard.where('lower(category) ILIKE ?', "%#{category.downcase}%").where('lower(difficulty) ILIKE ?', "%#{difficulty.downcase}").shuffle.sample(8)
+    SoundCard.where('lower(category) ILIKE ?', "%#{category.downcase}%").where('lower(difficulty) ILIKE ?',
+                                                                               "%#{difficulty.downcase}").shuffle.sample(8)
   end
 end

--- a/app/models/sound_card.rb
+++ b/app/models/sound_card.rb
@@ -5,7 +5,7 @@ class SoundCard < ApplicationRecord
   has_many :deck_cards, dependent: :destroy
   has_many :decks, through: :deck_cards
 
-  validates_presence_of :correct_answer, :category
+  validates_presence_of :correct_answer, :category, :difficulty
 
   before_validation :capitalize_answer
 

--- a/db/data/sound_cards.csv
+++ b/db/data/sound_cards.csv
@@ -1,97 +1,97 @@
-category,id,correct_answer
-Misc,4202,Boiling Water
-Instruments,14354,Mandolin
-Instruments,15401,Tibetian Bell
-Animals,16933,Donkey
-Instruments,19433,Snaredrum
-Instruments,19457,Xylophone
-Misc,23249,Can Opening
-Misc,26870,CD tray
-Misc,31166,Chopping Wood
-Machines,38567,Formula 1 Car
-Instruments,44641,Tenor Sax
-Machines,58811,Clock
-Instruments,59239,Gong
-Animals,59569,Horse
-Instruments,66352,Bongo Drum
-Animals,69570,Lion
-Animals,73371,Bee
-Instruments,74871,Electric Guitar
-Animals,74908,Whale
-Machines,78657,1200 baud modem
-Instruments,88655,Cello
-Misc,90205,Shovel
-Machines,103301,Chain saw
-Animals,103419,Pig
-Animals,115362,Mountain Lion
-Misc,116751,sheet metal
-Machines,118440,Drill
-Animals,121511,Cricket
-Machines,122822,Washing Machine
-Misc.,132029,Tape player
-Machines,138049,Typewriter
-Animals,139875,Elephant
-Instruments,145462,Steel Drum
-Misc.,158201,Record Player
-Machines,166690,Printer
-Instruments,175409,Trumbone
-Animals,194949,Crows
-Machines,196678,Coffee Grinder
-Machines,212616,Refrigerator
-Machines,216381,Lawn Mower
-Misc,221528,glass breaking
-Machines,235505,Stapler
-Machines,241763,elevator
-Misc,256564,Bag of chips
-Misc,256568,Cork Pop
-Instruments,257368,Ukelele
-Animals,260788,Howler Monkey
-Machines,324313,Commercial Plane
-Misc,326756,Balloon Deflate
-Misc,347163,firework
-Machines,347973,Propeller Plane
-Instruments,351705,Melodica
-Machines,362314,Table saw
-Misc.,365512,Pen clicking
-Misc,366364,Umbrella
-Machines,371815,Hair Dryer
-Animals,387544,Fox
-Machines,396992,Helicopter
-Animals,415153,Owl
-Misc,423777,Lighter
-Machines,424735,Vacuum
-Instruments,425542,Ukulele
-Instruments,427502,Clarinet
-Animals,444587,Kitten
-Animals,475043,White Eyed Vireo
-Animals,479235,Sheep
-Misc,484269,Balloon Deflating
-Instruments,486952,Harp
-Misc,494324,Bicycle Freewheeling
-Instruments,506266,Lute
-Instruments,510796,Maraca
-Animals,510917,Seagull
-Instruments,514847,Oboe
-Animals,515053,Cicada
-Instruments,517824,Toubeleki
-Instruments,523909,Violin
-Misc,533171,Vegtable Dicing
-Animals,540162,Snake
-Machines,584605,Car
-Machines,587043,Microwave
-Animals,590054,Geese
-Animals,592786,Turkey
-Misc,619018,Chalk on Board
-Machines,621132,Sewing Machine
-Instruments,627333,Harpsichord
-Instruments,632817,Acoustic Guitar
-Animals,634662,Cat
-Misc,636526,Spray Bottle
-Machines,649692,Air Conditioner
-Misc,655456,Controller Joystick
-Misc,662256,Tennis
-Animals,664882,Dog
-Machines,667383,Pencil Sharpener
-Animals,667579,Bat
-Misc,669395,Boat
-Instruments,564441,Bass Guitar
+category,id,correct_answer,difficulty
+Misc,4202,Boiling Water,medium
+Instruments,7647,Theramin,hard
+Instruments,14354,Mandolin,medium
+Instruments,15401,Tibetian Bell,medium
+Animals,16933,Donkey,easy
+Instruments,19433,Snaredrum,easy
+Instruments,19457,Xylophone,medium
+Misc,23249,Can Opening,easy
+Misc,26870,CD tray,hard
+Misc,240984,Chopping Wood,easy
+Machines,38567,Formula 1 Car,hard
+Instruments,44641,Tenor Sax,hard
+Machines,58811,Clock,medium
+Instruments,59239,Gong,easy
+Animals,59569,Horse,easy
+Instruments,66352,Bongo Drum,easy
+Animals,73371,Bee,medium
+Instruments,74871,Electric Guitar,medium
+Animals,74908,Whale,easy
+Machines,78657,1200 baud modem,hard
+Instruments,88655,Cello,medium
+Misc,90205,Shovel,medium
+Machines,103301,Chain saw,hard
+Animals,103419,Pig,easy
+Animals,115362,Mountain Lion,easy
+Misc,116751,sheet metal,medium
+Machines,118440,Drill,easy
+Animals,121511,Cricket,easy
+Machines,122822,Washing Machine,medium
+Misc.,132029,Tape player,medium
+Machines,138049,Typewriter,easy
+Animals,139875,Elephant,easy
+Instruments,145462,Steel Drum,easy
+Misc.,158201,Record Player,easy
+Machines,166690,Printer,medium
+Instruments,175409,Trombone,hard
+Misc,187607,Bubble Wrap,medium
+Animals,194949,Crows,medium
+Machines,196678,Coffee Grinder,hard
+Machines,212616,Refrigerator,hard
+Machines,216381,Lawn Mower,medium
+Misc,221528,glass breaking,easy
+Machines,235505,Stapler,medium
+Machines,241763,elevator,easy
+Misc,256564,Bag of chips,hard
+Misc,256568,Cork Pop,medium
+Animals,260788,Howler Monkey,easy
+Machines,324313,Commercial Plane,easy
+Misc,347163,firework,easy
+Machines,347973,Propeller Plane,easy
+Machines,362314,Table saw,hard
+Misc.,365512,Pen clicking,easy
+Misc,366364,Umbrella,easy
+Machines,371815,Hair Dryer,medium
+Animals,387544,Fox,hard
+Machines,396992,Helicopter,easy
+Animals,415153,Owl,easy
+Misc,423777,Lighter,medium
+Machines,424735,Vacuum,medium
+Instruments,425542,Ukulele,medium
+Instruments,427502,Clarinet,easy
+Animals,444587,Kitten,easy
+Animals,475043,White Eyed Vireo,hard
+Animals,479235,Goat,medium
+Misc,484269,Balloon Deflating,easy
+Instruments,486952,Harp,medium
+Misc,494324,Bicycle Freewheeling,easy
+Instruments,506266,Lute,hard
+Instruments,510796,Maraca,hard
+Animals,510917,Seagull,easy
+Instruments,514847,Oboe,hard
+Animals,515053,Cicada,easy
+Instruments,517824,Toubeleki,hard
+Instruments,523909,Violin,medium
+Misc,533171,Vegetable Dicing,easy
+Animals,540162,Snake,easy
+Instruments,546887,Melodica,hard
+Instruments,564441,Bass Guitar,medium
+Machines,584605,Car,easy
+Machines,587043,Microwave,easy
+Animals,590054,Geese,easy
+Animals,592786,Turkey,easy
+Animals,618980,Lion,easy
+Misc,619018,Chalk on Board,easy
+Machines,621132,Sewing Machine,medium
+Instruments,627333,Harpsichord,hard
+Instruments,632817,Acoustic Guitar,medium
+Animals,679954,Cat,easy
+Misc,636526,Spray Bottle,easy
+Machines,649692,Air Conditioner,easy
+Misc,655456,Controller Joystick,medium
+Misc,662256,Tennis,medium
+Animals,128074,Dog,medium
+Machines,667383,Pencil Sharpener,medium
+Animals,667579,Bat,hard
+Misc,669395,Boat,hard

--- a/db/migrate/20230322205830_create_sound_cards.rb
+++ b/db/migrate/20230322205830_create_sound_cards.rb
@@ -5,6 +5,7 @@ class CreateSoundCards < ActiveRecord::Migration[5.2]
     create_table :sound_cards do |t|
       t.string :correct_answer
       t.string :category
+      t.string :difficulty
       t.timestamps
     end
   end

--- a/db/migrate/20230331210820_create_decks.rb
+++ b/db/migrate/20230331210820_create_decks.rb
@@ -4,6 +4,7 @@ class CreateDecks < ActiveRecord::Migration[5.2]
   def change
     create_table :decks do |t|
       t.string :category
+      t.string :difficulty
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,53 +10,52 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_31_210914) do
-
+ActiveRecord::Schema.define(version: 20_230_331_210_914) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "deck_cards", force: :cascade do |t|
-    t.bigint "deck_id"
-    t.bigint "sound_card_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["deck_id"], name: "index_deck_cards_on_deck_id"
-    t.index ["sound_card_id"], name: "index_deck_cards_on_sound_card_id"
+  create_table 'deck_cards', force: :cascade do |t|
+    t.bigint 'deck_id'
+    t.bigint 'sound_card_id'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['deck_id'], name: 'index_deck_cards_on_deck_id'
+    t.index ['sound_card_id'], name: 'index_deck_cards_on_sound_card_id'
   end
 
-  create_table "decks", force: :cascade do |t|
-    t.string "category"
-    t.string "difficulty"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'decks', force: :cascade do |t|
+    t.string 'category'
+    t.string 'difficulty'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "leaderboards", force: :cascade do |t|
-    t.string "name"
-    t.integer "score"
-    t.string "category"
-    t.string "difficulty"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'leaderboards', force: :cascade do |t|
+    t.string 'name'
+    t.integer 'score'
+    t.string 'category'
+    t.string 'difficulty'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "sound_cards", force: :cascade do |t|
-    t.string "correct_answer"
-    t.string "category"
-    t.string "difficulty"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'sound_cards', force: :cascade do |t|
+    t.string 'correct_answer'
+    t.string 'category'
+    t.string 'difficulty'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "wrong_answers", force: :cascade do |t|
-    t.bigint "sound_card_id"
-    t.string "answer"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["sound_card_id"], name: "index_wrong_answers_on_sound_card_id"
+  create_table 'wrong_answers', force: :cascade do |t|
+    t.bigint 'sound_card_id'
+    t.string 'answer'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['sound_card_id'], name: 'index_wrong_answers_on_sound_card_id'
   end
 
-  add_foreign_key "deck_cards", "decks"
-  add_foreign_key "deck_cards", "sound_cards"
-  add_foreign_key "wrong_answers", "sound_cards"
+  add_foreign_key 'deck_cards', 'decks'
+  add_foreign_key 'deck_cards', 'sound_cards'
+  add_foreign_key 'wrong_answers', 'sound_cards'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,50 +10,53 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_230_331_210_914) do
+ActiveRecord::Schema.define(version: 2023_03_31_210914) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'deck_cards', force: :cascade do |t|
-    t.bigint 'deck_id'
-    t.bigint 'sound_card_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['deck_id'], name: 'index_deck_cards_on_deck_id'
-    t.index ['sound_card_id'], name: 'index_deck_cards_on_sound_card_id'
+  create_table "deck_cards", force: :cascade do |t|
+    t.bigint "deck_id"
+    t.bigint "sound_card_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["deck_id"], name: "index_deck_cards_on_deck_id"
+    t.index ["sound_card_id"], name: "index_deck_cards_on_sound_card_id"
   end
 
-  create_table 'decks', force: :cascade do |t|
-    t.string 'category'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "decks", force: :cascade do |t|
+    t.string "category"
+    t.string "difficulty"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'leaderboards', force: :cascade do |t|
-    t.string 'name'
-    t.integer 'score'
-    t.string 'category'
-    t.string 'difficulty'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "leaderboards", force: :cascade do |t|
+    t.string "name"
+    t.integer "score"
+    t.string "category"
+    t.string "difficulty"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'sound_cards', force: :cascade do |t|
-    t.string 'correct_answer'
-    t.string 'category'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "sound_cards", force: :cascade do |t|
+    t.string "correct_answer"
+    t.string "category"
+    t.string "difficulty"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'wrong_answers', force: :cascade do |t|
-    t.bigint 'sound_card_id'
-    t.string 'answer'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['sound_card_id'], name: 'index_wrong_answers_on_sound_card_id'
+  create_table "wrong_answers", force: :cascade do |t|
+    t.bigint "sound_card_id"
+    t.string "answer"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sound_card_id"], name: "index_wrong_answers_on_sound_card_id"
   end
 
-  add_foreign_key 'deck_cards', 'decks'
-  add_foreign_key 'deck_cards', 'sound_cards'
-  add_foreign_key 'wrong_answers', 'sound_cards'
+  add_foreign_key "deck_cards", "decks"
+  add_foreign_key "deck_cards", "sound_cards"
+  add_foreign_key "wrong_answers", "sound_cards"
 end

--- a/docs/post_deck.md
+++ b/docs/post_deck.md
@@ -8,9 +8,10 @@ This request requires an argument of category options for category include:
 ## Request Body
 Mutation
 ```
-mutation createDeck($category: String!){
+mutation createDeck($category: String!, $difficulty: String!){
     createDeck(input: {
-        category: $category
+        category: $category,
+        difficulty: $difficulty
     })
     {
         deck {
@@ -22,7 +23,8 @@ mutation createDeck($category: String!){
 Variables
 ```
 {
-    "category": "misc"
+    "category": "misc",
+    "difficulty": "easy"
 }
 ```
 ## Response Body

--- a/docs/post_deck.md
+++ b/docs/post_deck.md
@@ -1,10 +1,18 @@
 # Create a new deck
 This is the mutation that must be called in order to initialize a game, once the deck is created you will use the deck_id to [request each soundcard](/docs/get_soundcard.md) one at a time.
-This request requires an argument of category options for category include: 
+This request requires arguments `category` and `difficulty`.
+
+Options for category include: 
 - animals
 - instruments
 - machines
 - misc
+
+Options for difficulty include: 
+- easy
+- medium
+- hard
+
 ## Request Body
 Mutation
 ```

--- a/lib/tasks/sheets_load.rake
+++ b/lib/tasks/sheets_load.rake
@@ -6,7 +6,7 @@ namespace :sheets_load do
     SoundCard.destroy_all
     sound_card_data = SheetFacade.get_sheet('Sound%20Cards')
     sound_card_data.each do |sc|
-      SoundCard.create!({ category: sc[0], id: sc[1], correct_answer: sc[2] })
+      SoundCard.create!({ category: sc[0], id: sc[1], correct_answer: sc[2], difficulty: sc[3] })
     end
     ActiveRecord::Base.connection.reset_pk_sequence!('sound_cards')
   end

--- a/spec/data/sound_cards_test.csv
+++ b/spec/data/sound_cards_test.csv
@@ -1,97 +1,97 @@
-category,id,correct_answer
-Misc,4202,Boiling Water
-Instruments,14354,Mandolin
-Instruments,15401,Tibetian Bell
-Animals,16933,Donkey
-Instruments,19433,Snaredrum
-Instruments,19457,Xylophone
-Misc,23249,Can Opening
-Misc,26870,CD tray
-Misc,31166,Chopping Wood
-Machines,38567,Formula 1 Car
-Instruments,44641,Tenor Sax
-Machines,58811,Clock
-Instruments,59239,Gong
-Animals,59569,Horse
-Instruments,66352,Bongo Drum
-Animals,69570,Lion
-Animals,73371,Bee
-Instruments,74871,Electric Guitar
-Animals,74908,Whale
-Machines,78657,1200 baud modem
-Instruments,88655,Cello
-Misc,90205,Shovel
-Machines,103301,Chain saw
-Animals,103419,Pig
-Animals,115362,Mountain Lion
-Misc,116751,sheet metal
-Machines,118440,Drill
-Animals,121511,Cricket
-Machines,122822,Washing Machine
-Misc.,132029,Tape player
-Machines,138049,Typewriter
-Animals,139875,Elephant
-Instruments,145462,Steel Drum
-Misc.,158201,Record Player
-Machines,166690,Printer
-Instruments,175409,Trumbone
-Animals,194949,Crows
-Machines,196678,Coffee Grinder
-Machines,212616,Refrigerator
-Machines,216381,Lawn Mower
-Misc,221528,glass breaking
-Machines,235505,Stapler
-Machines,241763,elevator
-Misc,256564,Bag of chips
-Misc,256568,Cork Pop
-Instruments,257368,Ukelele
-Animals,260788,Howler Monkey
-Machines,324313,Commercial Plane
-Misc,326756,Balloon Deflate
-Misc,347163,firework
-Machines,347973,Propeller Plane
-Instruments,351705,Melodica
-Machines,362314,Table saw
-Misc.,365512,Pen clicking
-Misc,366364,Umbrella
-Machines,371815,Hair Dryer
-Animals,387544,Fox
-Machines,396992,Helicopter
-Animals,415153,Owl
-Misc,423777,Lighter
-Machines,424735,Vacuum
-Instruments,425542,Ukulele
-Instruments,427502,Clarinet
-Animals,444587,Kitten
-Animals,475043,White Eyed Vireo
-Animals,479235,Sheep
-Misc,484269,Balloon Deflating
-Instruments,486952,Harp
-Misc,494324,Bicycle Freewheeling
-Instruments,506266,Lute
-Instruments,510796,Maraca
-Animals,510917,Seagull
-Instruments,514847,Oboe
-Animals,515053,Cicada
-Instruments,517824,Toubeleki
-Instruments,523909,Violin
-Misc,533171,Vegtable Dicing
-Animals,540162,Snake
-Machines,584605,Car
-Machines,587043,Microwave
-Animals,590054,Geese
-Animals,592786,Turkey
-Misc,619018,Chalk on Board
-Machines,621132,Sewing Machine
-Instruments,627333,Harpsichord
-Instruments,632817,Acoustic Guitar
-Animals,634662,Cat
-Misc,636526,Spray Bottle
-Machines,649692,Air Conditioner
-Misc,655456,Controller Joystick
-Misc,662256,Tennis
-Animals,664882,Dog
-Machines,667383,Pencil Sharpener
-Animals,667579,Bat
-Misc,669395,Boat
-Instruments,564441,Bass Guitar
+category,id,correct_answer,difficulty
+Misc,4202,Boiling Water,medium
+Instruments,7647,Theramin,hard
+Instruments,14354,Mandolin,medium
+Instruments,15401,Tibetian Bell,medium
+Animals,16933,Donkey,easy
+Instruments,19433,Snaredrum,easy
+Instruments,19457,Xylophone,medium
+Misc,23249,Can Opening,easy
+Misc,26870,CD tray,hard
+Misc,240984,Chopping Wood,easy
+Machines,38567,Formula 1 Car,hard
+Instruments,44641,Tenor Sax,hard
+Machines,58811,Clock,medium
+Instruments,59239,Gong,easy
+Animals,59569,Horse,easy
+Instruments,66352,Bongo Drum,easy
+Animals,73371,Bee,medium
+Instruments,74871,Electric Guitar,medium
+Animals,74908,Whale,easy
+Machines,78657,1200 baud modem,hard
+Instruments,88655,Cello,medium
+Misc,90205,Shovel,medium
+Machines,103301,Chain saw,hard
+Animals,103419,Pig,easy
+Animals,115362,Mountain Lion,easy
+Misc,116751,sheet metal,medium
+Machines,118440,Drill,easy
+Animals,121511,Cricket,easy
+Machines,122822,Washing Machine,medium
+Misc.,132029,Tape player,medium
+Machines,138049,Typewriter,easy
+Animals,139875,Elephant,easy
+Instruments,145462,Steel Drum,easy
+Misc.,158201,Record Player,easy
+Machines,166690,Printer,medium
+Instruments,175409,Trombone,hard
+Misc,187607,Bubble Wrap,medium
+Animals,194949,Crows,medium
+Machines,196678,Coffee Grinder,hard
+Machines,212616,Refrigerator,hard
+Machines,216381,Lawn Mower,medium
+Misc,221528,glass breaking,easy
+Machines,235505,Stapler,medium
+Machines,241763,elevator,easy
+Misc,256564,Bag of chips,hard
+Misc,256568,Cork Pop,medium
+Animals,260788,Howler Monkey,easy
+Machines,324313,Commercial Plane,easy
+Misc,347163,firework,easy
+Machines,347973,Propeller Plane,easy
+Machines,362314,Table saw,hard
+Misc.,365512,Pen clicking,easy
+Misc,366364,Umbrella,easy
+Machines,371815,Hair Dryer,medium
+Animals,387544,Fox,hard
+Machines,396992,Helicopter,easy
+Animals,415153,Owl,easy
+Misc,423777,Lighter,medium
+Machines,424735,Vacuum,medium
+Instruments,425542,Ukulele,medium
+Instruments,427502,Clarinet,easy
+Animals,444587,Kitten,easy
+Animals,475043,White Eyed Vireo,hard
+Animals,479235,Goat,medium
+Misc,484269,Balloon Deflating,easy
+Instruments,486952,Harp,medium
+Misc,494324,Bicycle Freewheeling,easy
+Instruments,506266,Lute,hard
+Instruments,510796,Maraca,hard
+Animals,510917,Seagull,easy
+Instruments,514847,Oboe,hard
+Animals,515053,Cicada,easy
+Instruments,517824,Toubeleki,hard
+Instruments,523909,Violin,medium
+Misc,533171,Vegetable Dicing,easy
+Animals,540162,Snake,easy
+Instruments,546887,Melodica,hard
+Instruments,564441,Bass Guitar,medium
+Machines,584605,Car,easy
+Machines,587043,Microwave,easy
+Animals,590054,Geese,easy
+Animals,592786,Turkey,easy
+Animals,618980,Lion,easy
+Misc,619018,Chalk on Board,easy
+Machines,621132,Sewing Machine,medium
+Instruments,627333,Harpsichord,hard
+Instruments,632817,Acoustic Guitar,medium
+Animals,679954,Cat,easy
+Misc,636526,Spray Bottle,easy
+Machines,649692,Air Conditioner,easy
+Misc,655456,Controller Joystick,medium
+Misc,662256,Tennis,medium
+Animals,128074,Dog,medium
+Machines,667383,Pencil Sharpener,medium
+Animals,667579,Bat,hard
+Misc,669395,Boat,hard

--- a/spec/data/wrong_answers_test.csv
+++ b/spec/data/wrong_answers_test.csv
@@ -1,289 +1,289 @@
 sound_card_id,answer
-444587,Jaguar
-444587,Cougar
-444587,Minx
-194949,Fox
-194949,Pigeons
-194949,Ravens
-479235,Cow
-479235,Pig
-479235,Lamb
-74908,Shark
-74908,Dolphin
-74908,Dory
-121511,Cicada
-121511,Spider
-121511,Hummingbird
-59569,Screech Owl
-59569,Mink Frog
-59569,Zebra
-540162,Racoon
-540162,Hissing Cockroach
-540162,Cat
-634662,Snake
-634662,Hissing Cockroach
-634662,Duck
-664882,Pig
-664882,Bear
-664882,Horse
-88655,Upright Bass
-88655,Viola
-88655,Bassoon
-425542,Banjo
-425542,Mandolin
-425542,Guitar
-44641,Clarinet
-44641,Alto Sax
-44641,Trumpet
-145462,Snare Drum
-145462,Cow Bell
-145462,Gong
-510796,Cicada
-510796,Rattlesnake
-510796,Egg Shaker
-59239,Triangle
-59239,Cow Bell
-59239,Bass Drum
-627333,Harp
-627333,Mandolin
-627333,Keytar
-427502,French Horn
-427502,Flute
-427502,Saxaphone
-14354,Harpsichord
-14354,Ukulele
-14354,Guitar
-196678,Food Processor
-196678,Blender
-196678,Leaf Blower
-118440,Chainsaw
-118440,Impact Wrench
-118440,Jackhammer
-138049,Mechanical Keyboard
-138049,Cash Register
-138049,Punch Card Machine
-166690,Fax Machine
-166690,Laminator
-166690,Dial Up
-122822,Dryer
-122822,Jet Engine
-122822,Water Fountain
-371815,Vacuum Cleaner
-371815,Oscilating Fan
-371815,Leaf Blower
-667383,Fishing Rod
-667383,Wood Sculpting
-667383,Bicycle
-584605,Washing Machine
-584605,Motorcycle
-584605,Helicopter
-649692,Waterfall
-649692,Vinyl Popping
-649692,Washing Machine
-26870,Junk Drawer Closing
-26870,Cassette Player Ejecting
-26870,VHS Loading
-23249,Bottle Cap Twisting Off
-23249,Champagne Bottle Opening
-23249,Wine Bottle Opening
 4202,Hot Tub Jets
 4202,Coffee Percolating
 4202,Gurgling Drain
-256564,Raking Leaves
-256564,Grocery Bags
-256564,Cereal
-423777,Soda Can
-423777,Matchbook
-423777,Fidget Spinner
-655456,Keyboard
-655456,Campfire
-655456,Remote
-31166,Typing on a Keyboard
-31166,Boots on Snow
-31166,Door Closing
-326756,Hyena
-326756,Baby
-326756,Car Engine
-533171,Chopping Wood
-533171,Door Closing
-533171,Metronome
-139875,Water Buffalo
-139875,Rhino
-139875,Camel
-667579,Marmot
-667579,Rat
-667579,Cardinal
-475043,Leaf Warbler
-475043,Blackbird
-475043,American Sparrow
-260788,Mountain Lion
-260788,Gorilla
-260788,Hyena 
-115362,Tiger
-115362,Howler Monkey
-115362,Pug
-415153,Magpie
-415153,Elk
-415153,Coyote
-486952,Guitar
-486952,Lute
-486952,Lyre
-506266,Guitar
-506266,Banjo
-506266,Mandolin
-66352,Snare
-66352,Tambourine
-66352,Timpani
-396992,Airplane
-396992,Lawn Mower
-396992,Truck
-58811,Blinker
-58811,Typewriter
-58811,Light Switch
-587043,Conveyer Belt
-587043,Trimmer
-587043,Toaster
-256568,Bubble Wrap
-256568,Jar Lid
-256568,Suction Cup
-619018,Typewriter
-619018,Pencil
-619018,Chopsticks
-636526,Broom
-636526,Knife
-636526,Chalk
-669395,Sewing Machine
-669395,Lawnmower
-669395,Dishwasher
-90205,Tape
-90205,Sandpaper
-90205,Tin Can
-366364,sheets
-366364,paper
-366364,parachute
-216381,machine gun
-216381,sewing machine
-216381,typewriter
-621132,copy machine
-621132,fan
-621132,dryer
-424735,weed wacker
-424735,hair dryer
-424735,air fryer
-19457,glockenspiel
-19457,vibraphone
-19457,hand bell
-564441,bassoon
-564441,celle
-564441,baritone
-514847,flute
-514847,piccolo
-514847,clarinet
-103419,bear
-103419,dog
-103419,cat
-590054,macaw
-590054,osprey
-590054,duck
-515053,cricket
-515053,locust
-515053,monkey
-69570,Tiger
-69570,Cheetah
-69570,Grizzly Bear
-387544,Eagle
-387544,Mountain lion
-387544,Monkey
-592786,Chicken
-592786,Goose
-592786,Duck
-523909,Viola
-523909,Cello
-523909,Upright bass
-517824,Bongo
-517824,Djembe
-517824,Doumbek
-351705,Accordion
-351705,Oboe
-351705,Harmonica
-362314,Band Saw
-362314,Circular Saw
-362314,Drill press
-103301,Leaf Blower
-103301,weed wacker
-103301,Lawn Mower
-212616,Freezer
-212616,Air conditioner
-212616,oven
-365512,TV Remote
-365512,Mouse click
-365512,Flashlight
-132029,VCR Player
-132029,Camera shutter
-132029,Turning on lamp
-158201,Flourescent light
-158201,Rain drops
-158201,Light wind
-16933,Horse
-16933,Goat
-16933,Cow
-73371,Hornet
-73371,Humming Bird
-73371,Mosquito
-510917,Pelican
-510917,Eagle
-510917,Hawk
-19433,Cymbal
-19433,Triangle
-19433,Tambourine
-175409,Bass Trumpet
-175409,Baritone Horn
-175409,Euphonium
+7647,Ghost
+7647,Singing Saw
+7647,Tannerin
+14354,Harpsichord
+14354,Ukulele
+14354,Guitar
 15401,Dinner Bell
 15401,Wind chimes
 15401,Hang Drum
-235505,hole punch
-235505,tape dispenser
-235505,label maker
-78657,Fax machine
-78657,credit card reader
-78657,Dial-Up Internet modem
-241763,Escalator
-241763,Stair Lift
-241763,Dumbwaiter
-221528,Ice Cracking
-221528,Ceramic Breaking
-221528,Wind chimes
-347163,Thunder
-347163,Gun shots
-347163,Ballon Pop
-116751,Tin can
-116751,Aluminum foil
-116751,Jaw Harp
-74871,Bass
-74871,Synthesizer
-74871,Slide Guitar
-632817,Classical Guitar
-632817,Ukulele
-632817,Mandolin
-257368,Acoustic Guitar
-257368,Mandolin
-257368,Banjo
-324313,Vacuum Cleaner
-324313,Hair Dryer
-324313,Formula One Car
-347973,Lawn Mower
-347973,Helicopter
-347973,Boat with Propeller
+16933,Horse
+16933,Goat
+16933,Cow
+19433,Cymbal
+19433,Triangle
+19433,Tambourine
+19457,glockenspiel
+19457,vibraphone
+19457,hand bell
+23249,Bottle Cap Twisting Off
+23249,Champagne Bottle Opening
+23249,Wine Bottle Opening
+26870,Junk Drawer Closing
+26870,Cassette Player Ejecting
+26870,VHS Loading
+240984,Door Knocker
+240984,Typewriter
+240984,Smacking Gum
 38567,Top Fuel Dragster
 38567,MotoGP Motorcycle
 38567,Supercar
-662256,Ping Pong
-662256,Bandminton
-662256,Paddleball
+44641,Clarinet
+44641,Alto Sax
+44641,Trumpet
+58811,Blinker
+58811,Typewriter
+58811,Light Switch
+59239,Triangle
+59239,Cow Bell
+59239,Bass Drum
+59569,Screech Owl
+59569,Mink Frog
+59569,Zebra
+66352,Snare
+66352,Tambourine
+66352,Timpani
+73371,Hornet
+73371,Humming Bird
+73371,Mosquito
+74871,Bass
+74871,Synthesizer
+74871,Slide Guitar
+74908,Shark
+74908,Dolphin
+74908,Dory
+78657,Fax machine
+78657,credit card reader
+78657,Dial-Up Internet modem
+88655,Upright Bass
+88655,Viola
+88655,Bassoon
+90205,Tape
+90205,Sandpaper
+90205,Tin Can
+103301,Leaf Blower
+103301,weed wacker
+103301,Lawn Mower
+103419,bear
+103419,dog
+103419,cat
+115362,Tiger
+115362,Howler Monkey
+115362,Pug
+116751,Tin can
+116751,Aluminum foil
+116751,Mouth Harp
+118440,Chainsaw
+118440,Impact Wrench
+118440,Jackhammer
+121511,Cicada
+121511,Spider
+121511,Hummingbird
+122822,Dryer
+122822,Jet Engine
+122822,Water Fountain
+132029,VCR Player
+132029,Camera shutter
+132029,Turning on lamp
+138049,Mechanical Keyboard
+138049,Cash Register
+138049,Punch Card Machine
+139875,Water Buffalo
+139875,Rhino
+139875,Camel
+145462,Snare Drum
+145462,Cow Bell
+145462,Gong
+158201,Flourescent light
+158201,Rain drops
+158201,Light wind
+166690,Fax Machine
+166690,Laminator
+166690,Dial Up
+175409,Bass Trumpet
+175409,Baritone Horn
+175409,Euphonium
+187607,Fireworks
+187607,Cap Gun
+187607,Pop Rocks
+194949,Fox
+194949,Pigeons
+194949,Ravens
+196678,Food Processor
+196678,Blender
+196678,Leaf Blower
+212616,Freezer
+212616,Air conditioner
+212616,oven
+216381,machine gun
+216381, sewing machine
+216381,typewriter
+221528,Ice Cracking
+221528,Ceramic Breaking
+221528,Wind chimes
+235505,hole punch
+235505,tape dispenser
+235505,label maker
+241763,Escalator
+241763,Stair Lift
+241763,Dumbwaiter
+256564,Raking Leaves
+256564,Grocery Bags
+256564,Cereal
+256568,Bubble Wrap
+256568,Jar Lid
+256568,Suction Cup
+260788,Mountain Lion
+260788,Gorilla
+260788,Hyena 
+324313,Vacuum Cleaner
+324313,Hair Dryer
+324313,Formula One Car
+347163,Thunder
+347163,Gun shots
+347163,Ballon Pop
+347973,Lawn Mower
+347973,Helicopter
+347973,Boat with Propeller
+362314,Band Saw
+362314,Circular Saw
+362314,Drill press
+365512,TV Remote
+365512,Mouse click
+365512,Flashlight
+366364,sheets
+366364,paper
+366364,parachute
+371815,Vacuum Cleaner
+371815,Oscilating Fan
+371815,Leaf Blower
+387544,Eagle
+387544,Mountain lion
+387544,Monkey
+396992,Airplane
+396992,Lawn Mower
+396992,Truck
+415153,Magpie
+415153,Elk
+415153,Coyote
+423777,Soda Can
+423777,Matchbook
+423777,Fidget Spinner
+424735,weed wacker
+424735,hair dryer
+424735,air fryer
+425542,Banjo
+425542,Mandolin
+425542,Guitar
+427502,French Horn
+427502,Flute
+427502,Saxophone
+444587,Jaguar
+444587,Cougar
+444587,Minx
+475043,Leaf Warbler
+475043,Blackbird
+475043,American Sparrow
+479235,Sheep
+479235,Pig
+479235,Lamb
 484269,Fart
 484269,Tire Leak
 484269,Steam Escaping
+486952,Guitar
+486952,Lute
+486952,Lyre
 494324,Geiger Counter
 494324,Typewriter
 494324,Fingernails Tapping
+506266,Guitar
+506266,Banjo
+506266,Mandolin
+510796,Cicada
+510796,Rattlesnake
+510796,Egg Shaker
+510917,Pelican
+510917,Eagle
+510917,Hawk
+514847,flute
+514847,piccolo
+514847,clarinet
+515053,cricket
+515053,locust
+515053,monkey
+517824,Bongo
+517824,Djembe
+517824,Doumbek
+523909,Viola
+523909,Cello
+523909,Upright bass
+533171,Chopping Wood
+533171,Door Closing
+533171,Metronome
+540162,Racoon
+540162,Hissing Cockroach
+540162,Cat
+546887,Accordion
+546887,Oboe
+546887,Harmonica
+564441,bassoon
+564441,cello
+564441,baritone
+584605,Washing Machine
+584605,Motorcycle
+584605,Helicopter
+587043,Conveyer Belt
+587043,Trimmer
+587043,Toaster
+590054,macaw
+590054,osprey
+590054,duck
+592786,Chicken
+592786,Goose
+592786,Duck
+618980,Tiger
+618980,Cheetah
+618980,Grizzly Bear
+619018,Typewriter
+619018,Pencil
+619018,Chopsticks
+621132,copy machine
+621132,Fan
+621132,Dryer
+627333,Harp
+627333,Mandolin
+627333,Keytar
+632817,Classical Guitar
+632817,Ukulele
+632817,Mandolin
+679954,Snake
+679954,Hissing Cockroach
+679954,Duck
+636526,Broom
+636526,Knife
+636526,Chalk
+649692,Waterfall
+649692,Vinyl Popping
+649692,Washing Machine
+655456,Keyboard
+655456,Campfire
+655456,Remote
+662256,Ping Pong
+662256,Bandminton
+662256,Paddleball
+128074,Pig
+128074,Bear
+128074,Horse
+667383,Fishing Rod
+667383,Wood Sculpting
+667383,Bicycle
+667579,Marmot
+667579,Rat
+667579,Cardinal
+669395,Sewing Machine
+669395,Lawnmower
+669395,Dishwasher

--- a/spec/models/deck_spec.rb
+++ b/spec/models/deck_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Deck do
   describe 'validations' do
     it { should validate_presence_of :category }
+    it { should validate_presence_of :difficulty }
   end
 
   describe 'associations' do
@@ -13,21 +14,23 @@ RSpec.describe Deck do
   end
 
   describe 'get_cards' do
-    it 'should create 8 deckcards of the correct category' do
+    it 'should create 8 deckcards of the correct category and difficulty' do
       deck = Deck.create!(category: 'Animals', difficulty: 'easy')
 
       expect(deck.sound_cards.count).to eq(8)
       deck.sound_cards.each do |sc|
         expect(sc.category).to eq('Animals')
+        expect(sc.difficulty).to eq('easy')
       end
     end
 
-    it 'should create 8 deckcards of the correct category' do
+    it 'should create 8 deckcards of the correct category and difficulty' do
       deck = Deck.create!(category: 'misc', difficulty: 'medium')
 
       expect(deck.sound_cards.count).to eq(8)
       deck.sound_cards.each do |sc|
         expect(sc.category.include?('Misc')).to eq true
+        expect(sc.difficulty).to eq('medium')
       end
     end
   end
@@ -42,6 +45,7 @@ RSpec.describe Deck do
 
       expect(sound_card).to be_a SoundCard
       expect(sound_card.category).to eq('Instruments')
+      expect(sound_card.difficulty).to eq('medium')
       expect(deck.sound_cards.count).to eq(7)
 
       deck.return_sound_card

--- a/spec/models/deck_spec.rb
+++ b/spec/models/deck_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Deck do
 
   describe 'get_cards' do
     it 'should create 8 deckcards of the correct category' do
-      deck = Deck.create!(category: 'Animals')
+      deck = Deck.create!(category: 'Animals', difficulty: 'easy')
 
       expect(deck.sound_cards.count).to eq(8)
       deck.sound_cards.each do |sc|
@@ -23,7 +23,7 @@ RSpec.describe Deck do
     end
 
     it 'should create 8 deckcards of the correct category' do
-      deck = Deck.create!(category: 'misc')
+      deck = Deck.create!(category: 'misc', difficulty: 'medium')
 
       expect(deck.sound_cards.count).to eq(8)
       deck.sound_cards.each do |sc|
@@ -34,7 +34,7 @@ RSpec.describe Deck do
 
   describe 'return_sound_card' do
     it 'returns a soundcard and deletes the corresponding deck card' do
-      deck = Deck.create!(category: 'Instruments')
+      deck = Deck.create!(category: 'Instruments', difficulty: 'medium')
 
       expect(deck.sound_cards.count).to eq(8)
 

--- a/spec/models/sound_card_spec.rb
+++ b/spec/models/sound_card_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe SoundCard do
   describe 'validations' do
     it { should validate_presence_of :correct_answer }
     it { should validate_presence_of :category }
+    it { should validate_presence_of :difficulty }
   end
 
   describe 'associations' do

--- a/spec/models/sound_card_spec.rb
+++ b/spec/models/sound_card_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SoundCard do
 
   describe '#capitalize_answer' do
     it 'capitalizes the answer of the sound card' do
-      sc = SoundCard.create!(correct_answer: 'big bird', category: 'Animals')
+      sc = SoundCard.create!(correct_answer: 'big bird', category: 'Animals', difficulty: 'hard')
 
       expect(sc.correct_answer).to eq('Big Bird')
     end

--- a/spec/models/wrong_answer_spec.rb
+++ b/spec/models/wrong_answer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe WrongAnswer do
 
   describe '#capitalize_answer' do
     it 'capitalizes the answer of the sound card' do
-      sc = SoundCard.create!(correct_answer: 'Bird', category: 'Animals')
+      sc = SoundCard.create!(correct_answer: 'Bird', category: 'Animals', difficulty: 'hard')
       wa = sc.wrong_answers.create!(answer: 'the dog')
 
       expect(wa.answer).to eq('The Dog')

--- a/spec/requests/deck_mutation_spec.rb
+++ b/spec/requests/deck_mutation_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'deck mutation', type: :request do
     it 'returns a deck with no cards if category does not exist' do
       errors = decks_mutation('accents', 'hard').dig('createDeck', 'errors')
 
-      expect(errors.first).to eq('There are no sound cards for category accents')
+      expect(errors.first).to eq('There are no sound cards for category accents with difficulty hard')
       expect(Deck.last).to be nil
     end
 

--- a/spec/requests/deck_mutation_spec.rb
+++ b/spec/requests/deck_mutation_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'deck mutation', type: :request do
   it 'adds a deck entry to the database' do
-    mutation_response = decks_mutation('Animals')
+    mutation_response = decks_mutation('Animals', 'easy')
     deck = mutation_response['createDeck']['deck']
     errors = mutation_response['createDeck']['errors']
     new_deck = Deck.last
@@ -17,7 +17,7 @@ RSpec.describe 'deck mutation', type: :request do
 
   describe 'deck edge cases' do
     it 'returns a deck with correct categories case insensitively' do
-      mutation_response = decks_mutation('iNsTrumENTS')
+      mutation_response = decks_mutation('iNsTrumENTS', 'easy')
       new_deck = Deck.last
 
       expect(new_deck.category).to eq('iNsTrumENTS')
@@ -29,7 +29,7 @@ RSpec.describe 'deck mutation', type: :request do
 
   describe 'deck sad paths' do
     it 'returns a deck with no cards if category does not exist' do
-      errors = decks_mutation('accents').dig('createDeck', 'errors')
+      errors = decks_mutation('accents', 'hard').dig('createDeck', 'errors')
 
       expect(errors.first).to eq('There are no sound cards for category accents')
       expect(Deck.last).to be nil
@@ -56,11 +56,12 @@ RSpec.describe 'deck mutation', type: :request do
 
   private
 
-  def decks_mutation(category)
+  def decks_mutation(category, difficulty)
     response = gql <<-GQL
       mutation createDeck{
         createDeck(input: {
-          category: "#{category}"
+          category: "#{category}",
+          difficulty: "#{difficulty}"
         }) {
           deck {
             id

--- a/spec/requests/deck_mutation_spec.rb
+++ b/spec/requests/deck_mutation_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'deck mutation', type: :request do
         }
       GQL
       errors = response['errors']
-        
+
       expect(errors.count).to eq(1)
       expect(errors.first['message']).to eq("Argument 'difficulty' on InputObject 'CreateDeckInput' is required. Expected type String!")
       expect(Deck.last).to be nil

--- a/spec/requests/sound_card_query_spec.rb
+++ b/spec/requests/sound_card_query_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Sound Card Requests', type: :request do
     end
 
     it 'returns asound card in the correct category for the given deck id', :vcr do
-      deck_id = Deck.create!(category: 'Animals').id
+      deck_id = Deck.create!(category: 'Animals', difficulty: 'easy').id
       response = query_sound_cards_by_deck_id(deck_id)
       sound_card = response.dig('data', 'soundCard')
 
@@ -21,7 +21,7 @@ RSpec.describe 'Sound Card Requests', type: :request do
 
     describe 'Sound Card Sad Paths' do
       it 'returns an error if deck is out of cards', :vcr do
-        deck_id = Deck.create!(category: 'Animals').id
+        deck_id = Deck.create!(category: 'Animals', difficulty: 'Easy').id
         8.times do
           query_sound_cards_by_deck_id(deck_id)
         end
@@ -33,7 +33,7 @@ RSpec.describe 'Sound Card Requests', type: :request do
       end
 
       it 'returns an error if given deck id does not exist', :vcr do
-        Deck.create!(category: 'Misc')
+        Deck.create!(category: 'Misc', difficulty: 'Easy')
         deck_id = Deck.maximum(:id) + 1
 
         response = query_sound_cards_by_deck_id(deck_id)
@@ -52,7 +52,7 @@ RSpec.describe 'Sound Card Requests', type: :request do
   describe 'Sound card edge cases' do
     it 'returns a unique error if api limit is reached' do
       allow(SoundService).to receive(:get_sound_data).and_return({})
-      deck_id = Deck.create!(category: 'Misc').id
+      deck_id = Deck.create!(category: 'Misc', difficulty: 'easy').id
 
       response = query_sound_cards_by_deck_id(deck_id)
       errors = response['errors']

--- a/spec/requests/sound_card_query_spec.rb
+++ b/spec/requests/sound_card_query_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Sound Card Requests', type: :request do
     end
   end
 
-  describe 'Sound Card Queries' do
+  describe 'Sound card edge cases' do
     it 'returns a unique error if api limit is reached' do
       allow(SoundService).to receive(:get_sound_data).and_return({})
       deck_id = Deck.create!(category: 'Misc').id


### PR DESCRIPTION
## Query/Mutation Effected
Create deck mutation updated to require difficulty as an argument

Example Request:
```
mutation createDeck($category: String!, $difficulty: String!){
    createDeck(input: {
        category: $category,
        difficulty: $difficulty
    })
    {
        deck {
            id
        }
    }
}
```

## Describe Changes
- Add difficulty to mutation
- Added difficulty to soundcard and deck models
- Updated rake sheets_load task to account for difficulty
- Docs updated to reflect new mutation argument

## Requested Reviewer(s)
@sambcox or @ryancanton 